### PR TITLE
don't highlight trailing spaces on the line where the cursor is

### DIFF
--- a/stylesheets/trailing-spaces.less
+++ b/stylesheets/trailing-spaces.less
@@ -4,7 +4,7 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-.trailing-whitespace {
+.line:not(.cursor-line) .trailing-whitespace {
     background: @background-color-selected;
     border-radius: 2px;
 }

--- a/stylesheets/trailing-spaces.less
+++ b/stylesheets/trailing-spaces.less
@@ -4,7 +4,7 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-.line:not(.cursor-line) .trailing-whitespace {
+div.line:not(.cursor-line) .trailing-whitespace {
     background: @background-color-selected;
     border-radius: 2px;
 }


### PR DESCRIPTION
I found it distracting while typing to have the trailing space highlighted on the
current line.

This adds a :not(.cursor-line) selector to avoid this.
