### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Highlights trailing whitespace.
 
 Use the Atom package manager, which can be found in the Settings view or run `apm install trailing-spaces`  from the command line.
 
+## Configuration ##
+
+Configuration options are available for:
+- Enable/disable highlight on lines with a cursor
+- Enable/disable highlight on lines which contain only indentation
+
 ## Screenshot ##
 
 ![](http://snag.gy/OpJpI.jpg)
+

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -4,11 +4,23 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'Enable highlight for lines containing only indentation'
-
+    enableForCursorLines:
+      type: 'boolean'
+      default: false
+      description: 'Enable highlight for lines containing a cursor'
+  
   activate: (state) ->
+    # Observe "Enable For Indentation" config setting
     atom.config.observe 'trailing-spaces.enableForIndentation', (enable) ->
       if enable
         document.body.classList.add('trailing-spaces-highlight-indentation')
       else
         document.body.classList.remove('trailing-spaces-highlight-indentation')
+    
+    # Observe "Enable For Cursor Lines" config setting
+    atom.config.observe 'trailing-spaces.enableForCursorLines', (enable) ->
+      if enable
+        document.body.classList.add('trailing-spaces-highlight-cursor-lines')
+      else
+        document.body.classList.remove('trailing-spaces-highlight-cursor-lines')
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,14 @@
 module.exports =
+  config:
+    enableForIndentation:
+      type: 'boolean'
+      default: false
+      description: 'Enable highlight for lines containing only indentation'
+
   activate: (state) ->
+    atom.config.observe 'trailing-spaces.enableForIndentation', (enable) ->
+      if enable
+        document.body.classList.add('trailing-spaces-highlight-indentation')
+      else
+        document.body.classList.remove('trailing-spaces-highlight-indentation')
 
-  deactivate: ->
-
-  serialize: ->

--- a/styles/trailing-spaces.atom-text-editor.less
+++ b/styles/trailing-spaces.atom-text-editor.less
@@ -4,7 +4,33 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-.trailing-whitespace {
-    background: @background-color-selected;
-    border-radius: 2px;
+atom-text-editor::shadow {
+  // Only direct descendants of .lines; a comment is a "line within a line"
+  .lines > .line {
+    .trailing-whitespace {
+      background: @background-color-selected;
+      border-radius: 2px;
+      
+      &.indent-guide {
+        background: none;
+      }
+    }
+    
+    // Don't highlight whitespace on a line with a cursor
+    &.cursor-line {
+      .trailing-whitespace {
+        background: none;
+        transition: all 0.4s;
+        transition-delay: 0.1s;
+      }
+    }
+  }
 }
+
+// Enable highlight for lines with only indentation (based on config)
+.trailing-spaces-highlight-indentation atom-text-editor::shadow {
+    .lines > .line:not(.cursor-line) .trailing-whitespace.indent-guide {
+        background: @background-color-selected;
+    }
+}
+

--- a/styles/trailing-spaces.atom-text-editor.less
+++ b/styles/trailing-spaces.atom-text-editor.less
@@ -4,33 +4,52 @@
 // for a full listing of what's available.
 @import "ui-variables";
 
-atom-text-editor::shadow {
+atom-text-editor:not(.mini)::shadow {
   // Only direct descendants of .lines; a comment is a "line within a line"
   .lines > .line {
     .trailing-whitespace {
       background: @background-color-selected;
       border-radius: 2px;
       
+      // Disable highlight for the lines with only indentation
       &.indent-guide {
         background: none;
       }
     }
     
-    // Don't highlight whitespace on a line with a cursor
-    &.cursor-line {
-      .trailing-whitespace {
-        background: none;
-        transition: all 0.4s;
-        transition-delay: 0.1s;
-      }
+    // Disable highlight for lines with a cursor on them
+    &.cursor-line .trailing-whitespace {
+      background: none;
+      transition: all 0.4s;
+      transition-delay: 0.1s;
+    }
+  }
+}
+
+// Enable highlight for lines with a cursor on them (based on config)
+.trailing-spaces-highlight-cursor-lines {
+  atom-text-editor:not(.mini)::shadow {
+    .lines > .line.cursor-line .trailing-whitespace:not(.indent-guide) {
+      background: @background-color-selected;
     }
   }
 }
 
 // Enable highlight for lines with only indentation (based on config)
-.trailing-spaces-highlight-indentation atom-text-editor::shadow {
+.trailing-spaces-highlight-indentation {
+  atom-text-editor:not(.mini)::shadow {
     .lines > .line:not(.cursor-line) .trailing-whitespace.indent-guide {
-        background: @background-color-selected;
+      background: @background-color-selected;
     }
+  }
+}
+
+// Both config options enabled
+.trailing-spaces-highlight-cursor-lines.trailing-spaces-highlight-indentation {
+  atom-text-editor:not(.mini)::shadow {
+    .lines > .line.cursor-line .trailing-whitespace.indent-guide {
+      background: @background-color-selected;
+    }
+  }
 }
 


### PR DESCRIPTION
Some improvements to trailing-spaces:
- Don't highlight current line, as this can be distracting while typing
- Config option to not highlight lines containing only indentation
- Subtle CSS transition for the current line's highlight

This should be at least a partial fix for https://github.com/wpillar/atom-trailing-spaces/issues/6. I couldn't figure out a way to hide the highlight *while typing*, but at least this hides it for the line cursor is on.

The highlighting of "indentation only" lines was an issue I was going to create, but decided to fix it right away. Some people might actually want it there, so there's a config option for it. The implementation of the config option is a bit hackish, but it works well. :)

This is pretty much a complete rewrite of the package, but I managed to keep the package activation time under 5 ms (on my machine, anyway).