### PR TITLE
Make trailing spaces pop out more

### DIFF
--- a/styles/trailing-spaces.less
+++ b/styles/trailing-spaces.less
@@ -7,15 +7,15 @@
 atom-text-editor:not(.mini)::shadow {
   .lines .line {
     .trailing-whitespace {
-      background: @background-color-selected;
+      background: @background-color-error;
       border-radius: 2px;
-      
+
       // Disable highlight for the lines with only indentation
       &.indent-guide {
         background: none;
       }
     }
-    
+
     // Disable highlight for lines with a cursor on them
     &.cursor-line .trailing-whitespace {
       background: none;
@@ -29,7 +29,7 @@ atom-text-editor:not(.mini)::shadow {
 .trailing-spaces-highlight-cursor-lines {
   atom-text-editor:not(.mini)::shadow {
     .lines .line.cursor-line .trailing-whitespace:not(.indent-guide) {
-      background: @background-color-selected;
+      background: @background-color-error;
     }
   }
 }
@@ -38,7 +38,7 @@ atom-text-editor:not(.mini)::shadow {
 .trailing-spaces-highlight-indentation {
   atom-text-editor:not(.mini)::shadow {
     .lines .line:not(.cursor-line) .trailing-whitespace.indent-guide {
-      background: @background-color-selected;
+      background: @background-color-error;
     }
   }
 }
@@ -47,7 +47,7 @@ atom-text-editor:not(.mini)::shadow {
 .trailing-spaces-highlight-cursor-lines.trailing-spaces-highlight-indentation {
   atom-text-editor:not(.mini)::shadow {
     .lines .line.cursor-line .trailing-whitespace.indent-guide {
-      background: @background-color-selected;
+      background: @background-color-error;
     }
   }
 }

--- a/styles/trailing-spaces.less
+++ b/styles/trailing-spaces.less
@@ -7,15 +7,15 @@
 atom-text-editor:not(.mini)::shadow {
   .lines .line {
     .trailing-whitespace {
-      background: @background-color-error;
+      background: @background-color-warning;
       border-radius: 2px;
-
+      
       // Disable highlight for the lines with only indentation
       &.indent-guide {
         background: none;
       }
     }
-
+    
     // Disable highlight for lines with a cursor on them
     &.cursor-line .trailing-whitespace {
       background: none;
@@ -29,7 +29,7 @@ atom-text-editor:not(.mini)::shadow {
 .trailing-spaces-highlight-cursor-lines {
   atom-text-editor:not(.mini)::shadow {
     .lines .line.cursor-line .trailing-whitespace:not(.indent-guide) {
-      background: @background-color-error;
+      background: @background-color-warning;
     }
   }
 }
@@ -38,7 +38,7 @@ atom-text-editor:not(.mini)::shadow {
 .trailing-spaces-highlight-indentation {
   atom-text-editor:not(.mini)::shadow {
     .lines .line:not(.cursor-line) .trailing-whitespace.indent-guide {
-      background: @background-color-error;
+      background: @background-color-warning;
     }
   }
 }
@@ -47,7 +47,7 @@ atom-text-editor:not(.mini)::shadow {
 .trailing-spaces-highlight-cursor-lines.trailing-spaces-highlight-indentation {
   atom-text-editor:not(.mini)::shadow {
     .lines .line.cursor-line .trailing-whitespace.indent-guide {
-      background: @background-color-error;
+      background: @background-color-warning;
     }
   }
 }


### PR DESCRIPTION
`@background-color-selected` doesn't stand out in most themes, and it's easily confused with a selection.

This pull request uses `@background-color-error` instead which is red in One Dark. Alternatively, `@background-color-warning` could be used if you consider `@background-color-error` too much.

As for me, I like my trailing spaces to be easy targets so I can take them out swiftly! :dart:  thus ensuring they never make it to source control.

PS: Oh, and after making the change, I noticed there were pesky trailing spaces in `trailing-spaces.less` :wink: 